### PR TITLE
Add deprecated note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## Deprecated
+
+This repository has become too complex for a scaffolding. We believe that spliting this repository into two might be helpful for the two common and different use cases: cli-app or website.
+
+Therefore, we have decided to deprecate this repository in favor of:
+
+- [cli-skeleton](https://github.com/phel-lang/cli-skeleton): A skeleton to build your **cli-app** using Phel.
+- [web-skeleton](https://github.com/phel-lang/web-skeleton): A skeleton to build a **website** using Phel.
+
+---
+
 # Phel Scaffolding
 
 [Phel](https://phel-lang.org/) is a functional programming language that compiles to PHP. 


### PR DESCRIPTION
## 📚 Description

The current phel-scaffolding is full of complexity, mixing a cli-app and a website app. And because these two use cases need two different scopes, I created two separated repositories that simplifies the entry point of any new developer trying phel.

What do you think about this, @jenshaase and @JesusValera?

>**Note**: If you like the idea, we could even consider mark this repo as "public archive".